### PR TITLE
debian/ubuntu: pin tarantool-dev/tarantool-common

### DIFF
--- a/installer.tpl.sh
+++ b/installer.tpl.sh
@@ -211,6 +211,8 @@ install_apt ()
   echo "deb-src https://download.tarantool.org/tarantool/modules/${os}/ ${dist} main" >> ${apt_source_path}
   mkdir -p /etc/apt/preferences.d/
   echo -e "Package: tarantool\nPin: origin download.tarantool.org\nPin-Priority: 1001" > /etc/apt/preferences.d/tarantool
+  echo -e "\nPackage: tarantool-common\nPin: origin download.tarantool.org\nPin-Priority: 1001" >> /etc/apt/preferences.d/tarantool
+  echo -e "\nPackage: tarantool-dev\nPin: origin download.tarantool.org\nPin-Priority: 1001" >> /etc/apt/preferences.d/tarantool
   echo "The repository is setup! Tarantool can now be installed."
 
   apt_update

--- a/static/installer.sh
+++ b/static/installer.sh
@@ -245,6 +245,8 @@ install_apt ()
   echo "deb-src https://download.tarantool.org/tarantool/modules/${os}/ ${dist} main" >> ${apt_source_path}
   mkdir -p /etc/apt/preferences.d/
   echo -e "Package: tarantool\nPin: origin download.tarantool.org\nPin-Priority: 1001" > /etc/apt/preferences.d/tarantool
+  echo -e "\nPackage: tarantool-common\nPin: origin download.tarantool.org\nPin-Priority: 1001" >> /etc/apt/preferences.d/tarantool
+  echo -e "\nPackage: tarantool-dev\nPin: origin download.tarantool.org\nPin-Priority: 1001" >> /etc/apt/preferences.d/tarantool
   echo "The repository is setup! Tarantool can now be installed."
 
   apt_update


### PR DESCRIPTION
The situation occurs on Debian Bullseye (where tarantool-2.6 is in the
base repositories), when we enable our repository for tarantool-1.10.

The installer.sh script pins tarantool package from our repository. But
we should pin tarantool-dev package too, otherwise apt-get will unable
to install it:

```sh
$ apt-get install -y tarantool-dev
<...>
The following packages have unmet dependencies:
 tarantool-dev : Depends: tarantool (= 2.6.0-1) but 1.10.11.0.gf0b0e7ecf-1 is to be installed
E: Unable to correct problems, you have held broken pack
```

We should also pin tarantool-common, otherwise apt-get will install
incorrect version of the package:

```sh
$ apt-get install -y tarantool
<...>
$ dpkg -l | grep tarantool
ii  tarantool         1.10.11.0.gf0b0e7ecf-1  amd64 <...>
ii  tarantool-common  2.6.0-1                 all   <...>
ii  tarantool-dev     1.10.11.0.gf0b0e7ecf-1  amd64 <...>
```

`tarantoolctl rocks` will not work with those tarantool and
tarantool-common versions, see https://github.com/tarantool/tarantool/issues/5429.

Fixes #10