### PR TITLE
Support Ubuntu 21.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
           - "fedora:34"
           - "debian:bullseye"
           - "ubuntu:focal"
+          - "ubuntu:hirsute"
         type: [ live, pre-release, release ]
         version: ['1.10', '2.8', '2']
         exclude:

--- a/installer.tpl.sh
+++ b/installer.tpl.sh
@@ -56,6 +56,8 @@ detect_os ()
           dist="eoan"
         elif [ $ver_id = "20.04" ]; then
           dist="focal"
+        elif [ $ver_id = "21.04" ]; then
+          dist="hirsute"
         else
           unsupported_os
         fi
@@ -361,7 +363,7 @@ main ()
     echo "Setting up yum repository..."
     install_dnf
   elif ( [ ${os} = "debian" ] && [[ ${dist} =~ ^(jessie|stretch|buster|bullseye)$ ]] ) ||
-       ( [ ${os} = "ubuntu" ] && [[ ${dist} =~ ^(trusty|xenial|bionic|cosmic|disco|eoan|focal)$ ]] ); then
+       ( [ ${os} = "ubuntu" ] && [[ ${dist} =~ ^(trusty|xenial|bionic|cosmic|disco|eoan|focal|hirsute)$ ]] ); then
 
     echo
     echo "################################"

--- a/static/installer.sh
+++ b/static/installer.sh
@@ -96,6 +96,8 @@ detect_os ()
           dist="eoan"
         elif [ $ver_id = "20.04" ]; then
           dist="focal"
+        elif [ $ver_id = "21.04" ]; then
+          dist="hirsute"
         else
           unsupported_os
         fi
@@ -371,7 +373,7 @@ main ()
     echo "Setting up yum repository..."
     install_dnf
   elif ( [ ${os} = "debian" ] && [[ ${dist} =~ ^(jessie|stretch|buster|bullseye)$ ]] ) ||
-       ( [ ${os} = "ubuntu" ] && [[ ${dist} =~ ^(trusty|xenial|bionic|cosmic|disco|eoan|focal)$ ]] ); then
+       ( [ ${os} = "ubuntu" ] && [[ ${dist} =~ ^(trusty|xenial|bionic|cosmic|disco|eoan|focal|hirsute)$ ]] ); then
     echo "Setting up apt repository... "
     install_apt
   else


### PR DESCRIPTION
Support tarantool installation on Ubuntu 21.04 'Hirsute Hippo'.

Closes #12