### PR TITLE
Support Devuan releases (matching Debian)

### DIFF
--- a/installer.tpl.sh
+++ b/installer.tpl.sh
@@ -28,7 +28,7 @@ detect_os ()
       os_like=$(. /etc/os-release && echo $ID_LIKE)
       [[ $os_like = "ubuntu" ]] && os="ubuntu"
 
-      if [ $os = "debian" ]; then
+      if ( [ $os = "debian" ] ) || ( [ $os = "devuan" ] ); then
         dist=$(echo $(. /etc/os-release && echo $VERSION) | sed 's/^[[:digit:]]\+ (\(.*\))$/\1/')
         if [ -z "$dist" ]; then
           if grep -q "bullseye"* /etc/debian_version; then
@@ -365,12 +365,23 @@ main ()
     echo "Setting up yum repository..."
     install_dnf
   elif ( [ ${os} = "debian" ] && [[ ${dist} =~ ^(jessie|stretch|buster|bullseye)$ ]] ) ||
+       ( [ ${os} = "devuan" ] && [[ ${dist} =~ ^(jessie|ascii|beowulf|chimaera)$ ]] ) ||
        ( [ ${os} = "ubuntu" ] && [[ ${dist} =~ ^(trusty|xenial|bionic|cosmic|disco|eoan|focal|hirsute)$ ]] ); then
 
     echo
     echo "################################"
     echo "# Setting up apt repository... #"
     echo "################################"
+    # redirect devuan to debian repos
+    if [ ${os} = "devuan" ]; then
+	case ${dist} in
+	    ascii) ddist=stretch ;;
+	    beowulf) ddist=buster ;;
+	    chimaera) ddist=bullseye ;;
+	esac
+	dist=${ddist}
+	os=debian
+    fi
     install_apt
   else
     unsupported_os


### PR DESCRIPTION
This PR adds support for Devuan without the need to have extra packages (those for Debian basically work) just mapping release names. More info about Devuan:
- https://devuan.org
- https://distrowatch.com/dwres.php?resource=ranking
