### PR TITLE
Actualise OS installation. Ubuntu Groovy and Centos 8 fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,9 @@ jobs:
           - type: "pre-release"
             version: "2.8"
 
+    env:
+      INSTALLER: installer.sh
+
     steps:
 
     - name: Checkout
@@ -43,5 +46,18 @@ jobs:
     - name: Create Installer
       run: ./mkinstaller.py ${{ matrix.type }} ${{ matrix.version }}
 
+    - name: Workaround for Centos 8
+      if: matrix.image == 'centos:8'
+      run: |
+        cat > installer_centos_8.sh << EOL
+        #!/usr/bin/env bash
+        find /etc/yum.repos.d/ -type f -exec sed -i 's/mirrorlist=/#mirrorlist=/g' {} +
+        find /etc/yum.repos.d/ -type f -exec sed -i 's/#baseurl=/baseurl=/g' {} +
+        find /etc/yum.repos.d/ -type f -exec sed -i 's/mirror.centos.org/vault.centos.org/g' {} +
+        source /app/installer.sh
+        EOL
+        chmod +x installer_centos_8.sh
+        echo "INSTALLER=installer_centos_8.sh" >> $GITHUB_ENV
+
     - name: Set up Tarantool in docker
-      run: docker run --rm -v $(pwd):/app -e FORCE_INSTALL_TARANTOOL=True ${{ matrix.image }} sh -c "bash /app/installer.sh; tarantool --version"
+      run: docker run --rm -v $(pwd):/app -e FORCE_INSTALL_TARANTOOL=True ${{ matrix.image }} sh -c "bash /app/${{ env.INSTALLER }}; tarantool --version"

--- a/installer.tpl.sh
+++ b/installer.tpl.sh
@@ -56,6 +56,8 @@ detect_os ()
           dist="eoan"
         elif [ $ver_id = "20.04" ]; then
           dist="focal"
+        elif [ $ver_id = "20.10" ]; then
+          dist="groovy"
         elif [ $ver_id = "21.04" ]; then
           dist="hirsute"
         elif [ $ver_id = "21.10" ]; then
@@ -367,7 +369,7 @@ main ()
     echo "Setting up yum repository..."
     install_dnf
   elif ( [ ${os} = "debian" ] && [[ ${dist} =~ ^(jessie|stretch|buster|bullseye)$ ]] ) ||
-       ( [ ${os} = "ubuntu" ] && [[ ${dist} =~ ^(trusty|xenial|bionic|cosmic|disco|eoan|focal|hirsute|impish)$ ]] ); then
+       ( [ ${os} = "ubuntu" ] && [[ ${dist} =~ ^(trusty|xenial|bionic|cosmic|disco|eoan|focal|groovy|hirsute|impish)$ ]] ); then
 
     echo
     echo "################################"

--- a/static/installer.sh
+++ b/static/installer.sh
@@ -96,6 +96,8 @@ detect_os ()
           dist="eoan"
         elif [ $ver_id = "20.04" ]; then
           dist="focal"
+        elif [ $ver_id = "20.10" ]; then
+          dist="groovy"
         elif [ $ver_id = "21.04" ]; then
           dist="hirsute"
         elif [ $ver_id = "21.10" ]; then
@@ -377,7 +379,7 @@ main ()
     echo "Setting up yum repository..."
     install_dnf
   elif ( [ ${os} = "debian" ] && [[ ${dist} =~ ^(jessie|stretch|buster|bullseye)$ ]] ) ||
-       ( [ ${os} = "ubuntu" ] && [[ ${dist} =~ ^(trusty|xenial|bionic|cosmic|disco|eoan|focal|hirsute|impish)$ ]] ); then
+       ( [ ${os} = "ubuntu" ] && [[ ${dist} =~ ^(trusty|xenial|bionic|cosmic|disco|eoan|focal|groovy|hirsute|impish)$ ]] ); then
     echo "Setting up apt repository... "
     install_apt
   else


### PR DESCRIPTION
Add Ubuntu 20.10 Groovy to installer.sh

CentOS Linux 8 reached End Of Life on December 31st, 2021. The mirror list
with http://mirrorlist.centos.org doesn't work for it. The base URL with
http://mirror.centos.org doesn't work as well. So enabling repos from vault
mirrors:
  https://github.com/CentOS/sig-cloud-instance-images/issues/190

This is not a task of installer.sh, we need to prepare OS before running
installer.sh. installer_centos_8.sh is a script which deos this workaround.
It fixes repositories by enabling repos from vault mirrors then runs
installer.sh as usual.
