### PR TITLE
Fix shebang and sudoing installer.sh

### DIFF
--- a/installer.tpl.sh
+++ b/installer.tpl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o pipefail
 

--- a/installer.tpl.sh
+++ b/installer.tpl.sh
@@ -3,7 +3,7 @@
 set -o pipefail
 
 if [ $EUID != 0 ]; then
-    sudo "$0" "$@"
+    sudo bash "$0" "$@"
     exit $?
 fi
 

--- a/static/installer.sh
+++ b/static/installer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -uxo pipefail
 


### PR DESCRIPTION
Two minor fixes:
1) Change shebangs from `/bin/bash` to `/usr/bin/env bash` makes the script more portable and allows user to use preferred bash version.
2) Fix script calling itself with sudo, when execute bit isn't set.