### PR TITLE
Fix problem with Amazon Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,14 @@ jobs:
             type: "release"
             version: "2"
             build-type: "gc64"
+          - image: amazonlinux:2
+            type: "release"
+            version: "2"
+            build-type: "gc64"
+          - image: amazonlinux:2
+            type: "release"
+            version: "2"
+            build-type: ""
 
     env:
       INSTALLER: installer.sh

--- a/installer.tpl.sh
+++ b/installer.tpl.sh
@@ -356,7 +356,7 @@ install_yum ()
   echo "#########################"
   yum clean all
 
-  if [ $os = "centos" ]; then
+  if [ $os = "centos" ] || [ $os = "amzn" ]; then
     echo
     echo "#################################"
     echo "# Installing EPEL repository... #"
@@ -389,7 +389,7 @@ install_yum ()
   echo "########################"
   echo "# Updating metadata... #"
   echo "########################"
-  if [ $os = "centos" ]; then
+  if [ $os = "centos" ] || [ $os = "amzn" ]; then
     yum makecache -y --disablerepo='*' --enablerepo="tarantool_${ver_repo}" --enablerepo="tarantool_modules" --enablerepo='epel'
   elif [ $os = "redos" ]; then
     # RedOS doesn't support epel repo

--- a/static/installer.sh
+++ b/static/installer.sh
@@ -384,7 +384,7 @@ install_yum ()
   yum clean all
   echo "done."
 
-  if [ $os = "centos" ]; then
+  if [ $os = "centos" ] || [ $os = "amzn" ]; then
     echo -n "Installing EPEL repository... "
     if [ $dist = 6 ]; then
       curl https://www.getpagespeed.com/files/centos6-eol.repo --output /etc/yum.repos.d/CentOS-Base.repo
@@ -408,7 +408,7 @@ install_yum ()
   echo "done."
 
   echo -n "Updating metadata... "
-  if [ $os = "centos" ]; then
+  if [ $os = "centos" ] || [ $os = "amzn" ]; then
     yum makecache -y --disablerepo='*' --enablerepo="tarantool_${ver_repo}" --enablerepo="tarantool_modules" --enablerepo='epel'
   elif [ $os = "redos" ]; then
     # RedOS doesn't support epel repo


### PR DESCRIPTION
In the latest update, a bug was missed that broke support for Amazon Linux when adding support for RedOS. This commit fixes the bug by adding support for Amazon Linux to `if` statement which checked only CentOS. Also, add test for Amazon Linux.

