### PR TITLE
Fix problem with missing yum on RedOS 7.3

### DIFF
--- a/installer.tpl.sh
+++ b/installer.tpl.sh
@@ -418,7 +418,12 @@ install_dnf ()
   echo "########################"
   echo "# Updating metadata... #"
   echo "########################"
-  dnf -q makecache -y --disablerepo='*' --enablerepo="tarantool_${ver_repo}" --enablerepo="tarantool_modules"
+  if [ $os = "redos" ]; then
+    # RedOS doesn't support tarantool_modules repo
+    dnf -q makecache -y --disablerepo='*' --enablerepo="tarantool_${ver_repo}"
+  else
+    dnf -q makecache -y --disablerepo='*' --enablerepo="tarantool_${ver_repo}" --enablerepo="tarantool_modules"
+  fi
 
   echo "Tarantool ${ver} is ready to be installed by 'dnf install -y tarantool'"
 
@@ -445,7 +450,7 @@ main ()
     install_yum
   elif [ ${os} = "redos" ] && [[ ${dist} = "7.3" ]]; then
     echo "Setting up yum repository... "
-    install_yum
+    install_dnf
   elif [ ${os} = "fedora" ] && [[ ${dist} =~ ^(28|29|30|31|32|33|34|35|36|37|38)$ ]]; then
     echo "Setting up yum repository..."
     install_dnf

--- a/static/installer.sh
+++ b/static/installer.sh
@@ -430,7 +430,13 @@ install_dnf ()
   install_yum_repo
 
   echo -n "Updating metadata... "
-  dnf -q makecache -y --disablerepo='*' --enablerepo="tarantool_${ver_repo}" --enablerepo="tarantool_modules"
+  if [ $os = "redos" ]; then
+    # RedOS doesn't support tarantool_modules repo
+    dnf -q makecache -y --disablerepo='*' --enablerepo="tarantool_${ver_repo}"
+  else
+    dnf -q makecache -y --disablerepo='*' --enablerepo="tarantool_${ver_repo}" --enablerepo="tarantool_modules"
+  fi
+
   echo "done."
 
   echo
@@ -452,7 +458,7 @@ main ()
     install_yum
   elif [ ${os} = "redos" ] && [[ ${dist} = "7.3" ]]; then
     echo "Setting up yum repository... "
-    install_yum
+    install_dnf
   elif [ ${os} = "fedora" ] && [[ ${dist} =~ ^(28|29|30|31|32|33|34|35|36|37|38)$ ]]; then
     echo "Setting up yum repository..."
     install_dnf


### PR DESCRIPTION
The base Docker image, RedOS 7.3, incorporates the dnf package manager. However, a minimal image features the microdnf, which is intended to replace both yum and dnf, albeit with limited functionality. This has led to an issue where installer.sh does not operate as expected. The proposed solution rectifies the problem with the operation of installer.sh on the base image, specifically on the imges registry.red-soft.ru/ubi7/ubi.

Resolves #34