### PR TITLE
Allow installation of series-3 repos for any distro

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,46 @@
+name: Test installers (static repository)
+  
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test-installers-static:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - "centos:7"
+          - "fedora:40"
+          - "debian:bookworm"
+          - "ubuntu:jammy"
+          - "dyne/devuan:chimaera"
+          - "packpack/packpack:redos-7.3"
+          - "registry.astralinux.ru/library/alse:1.7"
+          - "almalinux:9"
+          - "opensuse/leap"
+        version: [ "3" ]
+        type: [ "pre-release", "release" ]
+
+    env:
+      INSTALLER: installer.sh
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup Python environment
+      uses: actions/setup-python@v5
+
+    - name: Setup Python requirements
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Create Installer
+      run: ./mkinstaller.py ${{ matrix.type }} ${{ matrix.version }}
+
+    - name: Set up Tarantool in docker
+      run: docker run --rm -v $(pwd):/app -e FORCE_INSTALL_TARANTOOL=True ${{ matrix.image }} sh -c "bash /app/${{ env.INSTALLER }}; tarantool --version;"

--- a/installer-static.tpl.sh
+++ b/installer-static.tpl.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+# Script to set up the `series-N` (N = 3, 4, etc.) and `modules` repositories
+# for Tarantool on any distro where RPM or DEB packages are used.
+
+function main() {
+  if yum --version > /dev/null 2>&1 || dnf --version > /dev/null 2>&1; then
+    setup_yum_dnf_repo
+  elif apt-get --version > /dev/null 2>&1; then
+    setup_apt_repo
+  elif zypper --version > /dev/null 2>&1; then
+    setup_zypper_repo
+  else
+    echo "Unknown package manager. Supported ones: apt-get, dnf, yum, zypper"
+    exit 1
+  fi
+}
+
+setup_apt_repo() {
+  apt-get update
+  apt-get -y install apt-transport-https curl gnupg
+
+  gpg_key_url="https://download.tarantool.org/tarantool/{{ rtype }}/series-{{ tarantool_version }}/gpgkey"
+  gpg_key_url_modules="https://download.tarantool.org/tarantool/release/modules/gpgkey"
+  apt_source_path="/etc/apt/sources.list.d/tarantool_{{ tarantool_version }}_static.list"
+
+  curl -L "${gpg_key_url}" | apt-key add -
+  curl -L "${gpg_key_url_modules}" | apt-key add -
+
+  echo "deb https://download.tarantool.org{% if usr_id %}/{{ usr_id }}{% endif %}/tarantool/{{ rtype }}/series-{{ tarantool_version }}/linux-deb/ static main" > ${apt_source_path}
+  echo "deb https://download.tarantool.org{% if usr_id %}/{{ usr_id }}{% endif %}/tarantool/release/modules/linux-deb static main" >> ${apt_source_path}
+
+  mkdir -p /etc/apt/preferences.d/
+  echo -e "Package: tarantool\nPin: origin download.tarantool.org{% if usr_id %}/{{ usr_id }}{% endif %}\nPin-Priority: 1001" > /etc/apt/preferences.d/tarantool
+  echo -e "\nPackage: tarantool-common\nPin: origin download.tarantool.org{% if usr_id %}/{{ usr_id }}{% endif %}\nPin-Priority: 1001" >> /etc/apt/preferences.d/tarantool
+  echo -e "\nPackage: tarantool-dev\nPin: origin download.tarantool.org{% if usr_id %}/{{ usr_id }}{% endif %}\nPin-Priority: 1001" >> /etc/apt/preferences.d/tarantool
+
+  apt-get update
+
+  if [[ ${FORCE_INSTALL_TARANTOOL:-False} = "True" ]]; then
+    echo "Installing Tarantool {{ tarantool_version }}"
+    DEBIAN_FRONTEND=noninteractive apt-get -y install tarantool
+  else
+    echo "Tarantool {{ tarantool_version }} is ready to be installed by 'apt-get -y install tarantool'"
+  fi
+}
+
+setup_yum_dnf_repo() {
+  cat <<EOF > /etc/yum.repos.d/tarantool_{{ tarantool_version }}_static.repo
+[tarantool]
+name=Tarantool
+baseurl=https://download.tarantool.org{% if usr_id %}/{{ usr_id }}{% endif %}/tarantool/{{ rtype }}/series-{{ tarantool_version }}/linux-rpm/static/\$basearch/
+gpgkey=https://download.tarantool.org/tarantool/{{ rtype }}/series-{{ tarantool_version }}/gpgkey
+repo_gpgcheck=1
+gpgcheck=0
+enabled=1
+priority=1
+
+[tarantool_modules]
+name=Tarantool modules
+baseurl=https://download.tarantool.org{% if usr_id %}/{{ usr_id }}{% endif %}/tarantool/release/modules/linux-rpm/static/\$basearch/
+gpgkey=https://download.tarantool.org/tarantool/release/modules/gpgkey
+repo_gpgcheck=1
+gpgcheck=0
+enabled=1
+priority=1
+EOF
+
+  if yum --version > /dev/null 2>&1; then
+    if [[ ${FORCE_INSTALL_TARANTOOL:-False} = "True" ]]; then
+      echo "Installing Tarantool {{ tarantool_version }}"
+      yum -y install tarantool
+    else
+      echo "Tarantool {{ tarantool_version }} is ready to be installed by 'yum -y install tarantool'"
+    fi
+  else
+    if [[ ${FORCE_INSTALL_TARANTOOL:-False} = "True" ]]; then
+      echo "Installing Tarantool {{ tarantool_version }}"
+      dnf -y install tarantool
+    else
+      echo "Tarantool {{ tarantool_version }} is ready to be installed by 'dnf -y install tarantool'"
+    fi
+  fi
+}
+
+setup_zypper_repo() {
+  rpm --import https://download.tarantool.org/tarantool/{{ rtype }}/series-{{ tarantool_version }}/gpgkey
+  rpm --import https://download.tarantool.org/tarantool/release/modules/gpgkey
+  cat <<EOF > /etc/zypp/repos.d/tarantool_{{ tarantool_version }}_static.repo
+[tarantool]
+name=Tarantool
+baseurl=https://download.tarantool.org{% if usr_id %}/{{ usr_id }}{% endif %}/tarantool/{{ rtype }}/series-{{ tarantool_version }}/linux-rpm/static/\$basearch/
+gpgkey=https://download.tarantool.org/tarantool/{{ rtype }}/series-{{ tarantool_version }}/gpgkey
+repo_gpgcheck=1
+gpgcheck=0
+enabled=1
+priority=1
+
+[tarantool_modules]
+name=Tarantool modules
+baseurl=https://download.tarantool.org{% if usr_id %}/{{ usr_id }}{% endif %}/tarantool/release/modules/linux-rpm/static/\$basearch/
+gpgkey=https://download.tarantool.org/tarantool/release/modules/gpgkey
+repo_gpgcheck=1
+gpgcheck=0
+enabled=1
+priority=1
+EOF
+
+  if [[ ${FORCE_INSTALL_TARANTOOL:-False} = "True" ]]; then
+    echo "Installing Tarantool {{ tarantool_version }}"
+    zypper install -y tarantool
+  else
+    echo "Tarantool {{ tarantool_version }} is ready to be installed by 'zypper install -y tarantool'"
+  fi
+}
+
+echo "Setting up the repository for Tarantool {{ tarantool_version }}"
+
+main

--- a/installer.tpl.sh
+++ b/installer.tpl.sh
@@ -428,7 +428,7 @@ install_dnf ()
   echo "Tarantool ${ver} is ready to be installed by 'dnf install -y tarantool'"
 
   if [[ ${FORCE_INSTALL_TARANTOOL:-False} = "True" ]]; then
-    yum -y install tarantool
+    dnf -y install tarantool
   fi
 
 }

--- a/mkinstaller.py
+++ b/mkinstaller.py
@@ -6,11 +6,22 @@ from jinja2 import Template
 
 
 if __name__ == "__main__":
-    repo_type = sys.argv[1]
-    ver = sys.argv[2]
+    if len(sys.argv) != 3:
+        print("Usage: mkinstaller.py <repo_type> <tarantool_version>")
+        sys.exit(1)
+    else:
+        repo_type = sys.argv[1]
+        ver = sys.argv[2]
 
-    with open("installer.tpl.sh", 'r') as file:
-        template = Template(file.read())
+    if ver >= "1" and ver < "3":
+        with open("installer.tpl.sh", 'r') as file:
+            template = Template(file.read())
+    elif ver >= "3":
+        with open("installer-static.tpl.sh", 'r') as file:
+            template = Template(file.read())
+    else:
+        print('Wrong version')
+        exit(1)
 
     installer = template.render({
         'tarantool_version': ver,


### PR DESCRIPTION
Add a new template for making the installer.sh script which can set up the `series-3` and `modules` repositories for Tarantool on any distro where RPM or DEB packages are used.

Closes #36